### PR TITLE
Rate limit, small bug fix and validateUpdateStatus middleware added

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,7 +35,7 @@ jobs:
       # Backend tests (when setup is completed)
       - name: Run backend tests
         working-directory: ./back-end
-        run: npm test
+        run: npm test:ci
         continue-on-error: false
         
   build:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,6 +9,10 @@ jobs:
     name: Test and Lint
     runs-on: ubuntu-latest
     
+    env:
+      JWT_SECRET: dummysecret
+      JWT_EXPIRES_IN: 1h
+      
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,7 +35,7 @@ jobs:
       # Backend tests (when setup is completed)
       - name: Run backend tests
         working-directory: ./back-end
-        run: npm test:ci
+        run: npm run test:ci
         continue-on-error: false
         
   build:

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
@@ -1127,9 +1128,9 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -2240,9 +2241,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.112",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.112.tgz",
-      "integrity": "sha512-oen93kVyqSb3l+ziUgzIOlWt/oOuy4zRmpwestMn4rhFWAoFJeFuCVte9F2fASjeZZo7l/Cif9TiyrdW4CwEMA==",
+      "version": "1.5.113",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.113.tgz",
+      "integrity": "sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2512,6 +2513,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "test:ci": "jest --runInBand --detectOpenHandles",
     "start": "node server.js",
     "dev": "nodemon server.js"
   },
@@ -15,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",

--- a/back-end/src/__tests__/integration/applicationDAO.test.js
+++ b/back-end/src/__tests__/integration/applicationDAO.test.js
@@ -37,6 +37,8 @@ describe("ApplicationDAO", () => {
    */
   beforeAll(async () => {
     await db.setupDatabase();
+    await db.clearDatabase();
+
     Application = require("../../models/applicationModel");
     Role = require("../../models/roleModel");
     Person = require("../../models/personModel");
@@ -67,7 +69,7 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
-    await clearDatabase();
+    await db.clearDatabase();
     await db.closeDatabase();
 });
     describe("applyForJobTransactionally",() =>{

--- a/back-end/src/__tests__/integration/competenceDAO.test.js
+++ b/back-end/src/__tests__/integration/competenceDAO.test.js
@@ -17,6 +17,8 @@ describe("CompetenceDAO", () => {
      */
     beforeAll(async () => {
       await db.setupDatabase();
+      await db.clearDatabase();
+
       Competence = require("../../models/competenceModel");
       const CompetenceDAO = require("../../integration/competenceDAO");
       competenceDAO = new CompetenceDAO();
@@ -31,7 +33,7 @@ describe("CompetenceDAO", () => {
      * Removes the created Role, terminates connection
      */
     afterAll(async () => {
-      await clearDatabase()
+      await db.clearDatabase()
       await db.closeDatabase();
       personDAO = null;
     });

--- a/back-end/src/__tests__/integration/personDAO.test.js
+++ b/back-end/src/__tests__/integration/personDAO.test.js
@@ -27,6 +27,7 @@ describe("PersonDAO", () => {
    */
   beforeAll(async () => {
     await db.setupDatabase();
+    await db.clearDatabase();
     Role = require("../../models/roleModel");
     Person = require("../../models/personModel");
     PersonDAO = require("../../integration/personDAO");
@@ -42,7 +43,7 @@ describe("PersonDAO", () => {
    * Removes the created Role, terminates connection
    */
   afterAll(async () => {
-    await clearDatabase()
+    await db.clearDatabase();
     await db.closeDatabase();
     personDAO = null;
   });

--- a/back-end/src/__tests__/mocks/databaseMock.js
+++ b/back-end/src/__tests__/mocks/databaseMock.js
@@ -3,17 +3,20 @@ const { Sequelize } = require("sequelize");
 let sequelize;
 
 async function setupDatabase() {
+  if (!sequelize) {
+    sequelize = new Sequelize({
+      dialect: "sqlite",
+      storage: ":memory:",
+      logging: false,
+    });
 
-  sequelize = new Sequelize({
-    dialect: 'sqlite',
-    storage: ':memory:',
-    logging: false,
-  });
-  await sequelize.authenticate();
+    await sequelize.authenticate();
+  }
 }
 
 async function syncDatabase() {
-  await sequelize.sync({ force: true });
+  if (!sequelize) await setupDatabase();
+    await sequelize.sync({ force: true });
 }
 
 async function closeDatabase() {
@@ -34,8 +37,12 @@ function getSequelize() {
   }
   return sequelize;
 }
+async function init() {
+  await setupDatabase();
+}
 
 module.exports = {
+  init,
   setupDatabase,
   syncDatabase,
   closeDatabase,

--- a/back-end/src/__tests__/server.test.js
+++ b/back-end/src/__tests__/server.test.js
@@ -41,6 +41,7 @@ describe("Testing Backend full flow use cases with dummy database",()=>{
 
     beforeAll(async () => {
         await db.init();
+        await db.clearDatabase();
         Person = require("../models/personModel");
         Competence = require("../models/competenceModel");
         CompetenceProfile = require("../models/competenceProfileModel");
@@ -63,6 +64,7 @@ describe("Testing Backend full flow use cases with dummy database",()=>{
 
     afterAll(async () =>{
         await appinstance.close()
+        await db.clearDatabase();
         await db.closeDatabase();
     });
 

--- a/back-end/src/__tests__/server.test.js
+++ b/back-end/src/__tests__/server.test.js
@@ -1,0 +1,278 @@
+/**
+ * Backend full flow use cases
+ */
+jest.resetModules();
+jest.doMock("../config/database.js", () => require("./mocks/databaseMock.js"));
+const db = require("../config/database.js");
+
+const Logger = require("../utils/logger");
+jest.mock("../utils/logger");
+Logger.mockImplementation(() => ({
+    log: jest.fn()
+}));
+
+// Models
+let Role, Person, Competence, Application, CompetenceProfile, Availability;
+
+// input data
+const recruiterEmail = "recruiter@amusementpark.com"
+const recruitePassword = "Recruiter1"
+const userEmail = "user@test.se"
+const userPassword = "Password1"
+
+
+const setupDummyDB = (async ()=>{
+    await Role.create({role_id: 1, name: "recruiter"});
+    await Role.create({role_id: 2, name: "applicant"});
+    await Competence.create({competence_id: 1, name: "Rollecoaster"})
+    await Competence.create({competence_id: 2, name: "Ticket Sales"})
+    await Person.create({
+        name: "Johanna", 
+        surname: "Morgan", 
+        pnr: "19930101-1234", 
+        email: recruiterEmail,
+        password: recruitePassword,
+        role_id: 1,
+    })
+});
+
+describe("Testing Backend full flow use cases with dummy database",()=>{
+    let app, request, appinstance;
+
+    beforeAll(async () => {
+        await db.init();
+        Person = require("../models/personModel");
+        Competence = require("../models/competenceModel");
+        CompetenceProfile = require("../models/competenceProfileModel");
+        Availability = require("../models/availabilityModel.js");
+        Role = require("../models/roleModel");
+        Application = require("../models/applicationModel");
+
+        await db.syncDatabase();
+    
+        await setupDummyDB(); 
+    
+        const server = require("../../server");
+        app = server.app;
+        appinstance = server;
+        request = require("supertest");
+    });
+    
+    
+
+
+    afterAll(async () =>{
+        await appinstance.close()
+        await db.closeDatabase();
+    });
+
+    describe("Testing Setup",() => {
+        test("Should return all schemas from mock db", async () => {
+            const tables = [
+                { name: "role" },
+                { name: "person" },
+                { name: "competence" },
+                { name: "application" },
+                { name: "competence_profile" },
+                { name: "availability" }
+              ]
+            const res = await db.getSequelize().showAllSchemas();
+            expect(res).toEqual(tables)
+        })
+        test("Should return a list of 1 persons if recruiter was created", async () =>{
+            const res = await Person.findAll()
+            expect(Array.isArray(res)).toBe(true);
+            expect(res.length).toBe(1); 
+        })
+        test("Should verify db is mockdb by being of type sqllite", () => {
+            const sequelize = db.getSequelize();
+            expect(sequelize.options.dialect).toBe("sqlite");
+        })
+        test("Should return 404 with an invalid route", async () => {
+            await request(app).get("/test").expect(404);
+        });
+        test("Should return 401  if not authenticated", async () => {
+            await request(app).get("/api/person/me").expect(401);
+        });
+        test("Should return 401  if not authenticated", async () => {
+            await request(app).get("/api/person/me").set("Authorization", "Bearer dummy-token").expect(401);
+        });
+        test("Should return 401  if not authenticated", async () => {
+            await request(app).get("/api/application/all").set("Authorization", "Bearer dummy-token").expect(401);
+        });
+    });
+
+    describe("Applicant Use case",() => {
+        const person = { 
+            name: "John", 
+            surname: "Doe", 
+            pnr: "19900101-1234", 
+            email: userEmail, 
+            password: userPassword 
+        };
+        let token = "dummy"
+
+        const validApplication =  {
+            competences: [{ competence_id: 1, years_of_experience: 5 }],
+            availabilities: [{ from_date: "2023-01-01", to_date: "2023-12-31" }]
+        }
+
+        test("should send reject with invalid input", async() =>{
+            await request(app)
+            .post("/api/person/create-account")
+            .send({name:person.name, surname: person.surname, pnr: "null", email: person.email, password: person.password})
+            .expect(400)
+        })
+        test("should create the person", async() =>{
+            const res = await request(app)
+            .post("/api/person/create-account")
+            .send(person)
+            .expect(201)
+        })
+        test("should login the person and return token", async () => {
+            const res = await request(app)
+            .post("/api/person/login")
+            .send({email: person.email, password: person.password})
+            .expect(200)
+
+            expect(res.body.data.token).toBeDefined()
+            token = res.body.data.token;
+        })
+        test("should return person data", async () =>{
+            const res= await request(app)
+                .get("/api/person/me")
+                .set("Authorization", `Bearer ${token}`)
+                .expect(200);
+            expect(res.body.data.pnr).toBe(person.pnr)
+        })
+        test("should not be able to view recruiter pages", async () => {
+            const res= await request(app)
+            .get("/api/application/all")
+            .set("Authorization", `Bearer ${token}`)
+            .expect(401);
+        });
+
+        test("should have 0 applications", async () => {
+            const res= await request(app)
+            .get("/api/application/my-application")
+            .set("Authorization", `Bearer ${token}`)
+            .expect(404);
+        })
+
+        test("should create an application", async () => {
+            const response = await request(app)
+                .post("/api/application/apply")
+                .set("Authorization", `Bearer ${token}`)
+                .send(validApplication)
+                .expect(201)
+        })
+
+        test("should return users application", async () => {
+            const res= await request(app)
+            .get("/api/application/my-application")
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+            expect(res.body.data.applicant.email).toBe(person.email)
+            expect(res.body.data.competences.competence_id).toBe(validApplication.competences.competence_id)
+            expect(res.body.data.status).toBe("unhandled")
+        })
+    })
+
+    describe("Recruiter use case", () => {
+        let token, applicationID;
+        test("should login the recruiter", async () => {
+            const res = await request(app)
+            .post("/api/person/login")
+            .send({email: recruiterEmail, password: recruitePassword})
+            .expect(200)
+            
+            expect(res.body.data.person.role).toBe("recruiter")
+            expect(res.body.data.token).toBeDefined()
+            token = res.body.data.token;
+        })
+        test("should allow recruite to view recruiter area", async () => {
+            const res= await request(app)
+            .get("/api/application/all")
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+            expect(Array.isArray(res.body.data)).toBe(true);
+            expect(res.body.data.length).toBe(1); 
+            expect(res.body.data[0].application_id).toBeDefined()
+
+            applicationID = res.body.data[0].application_id;
+        })
+        test("should allow to request for the application id", async () => {
+            const res= await request(app)
+            .get(`/api/application/${applicationID}`)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+            expect(res.body.data).toBeDefined();
+            expect(res.body.data.application_id).toBe(applicationID)
+            expect(res.body.data.status).toBe("unhandled")
+        })
+
+        test("should update the status of the application", async () => {
+            const res = await request(app)
+            .patch(`/api/application/${applicationID}/status`)
+            .set("Authorization", `Bearer ${token}`)
+            .send({ status: "accepted" })
+            .expect(200);
+
+            expect(res.body.data).toBeDefined();
+            expect(res.body.data.application_id).toBe(applicationID)
+            expect(res.body.data.status).toBe("accepted")
+        })
+
+        test("should show the updated status of the application", async () => {
+            const res= await request(app)
+            .get(`/api/application/${applicationID}`)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+            expect(res.body.data).toBeDefined();
+            expect(res.body.data.application_id).toBe(applicationID)
+            expect(res.body.data.status).not.toBe("unhandled")
+            expect(res.body.data.status).toBe("accepted")
+        })
+    })
+
+    
+    describe("Rate Limiting Tests", () => {
+        
+        test("Should block requests after limit is exceeded", async () => {
+            const res = await request(app)
+            .post("/api/person/login")
+            .send({email: recruiterEmail, password: recruitePassword})
+            .expect(200)
+    
+            expect(res.body.data.token).toBeDefined()
+            token = res.body.data.token;
+
+            for (let i = 0; i < 101; i++) { 
+                await request(app)
+                .get("/api/person/me")
+                .set("Authorization", `Bearer ${token}`)
+            }
+            const response = await request(app)
+                .get("/api/person/me")
+                .set("Authorization", `Bearer ${token}`)
+            expect(response.status).toBe(429); 
+        });
+
+        test("Should block requests after limit is exceeded for not logged in user", async () => {
+ 
+            for (let i = 0; i < 101; i++) { 
+                await request(app)
+                .get("/api/application/all")
+                .set("Authorization", `Bearer dummy`)
+            }
+            const response = await request(app)
+                .get("/api/application/apply")
+                .set("Authorization", `Bearer dummy`)
+            expect(response.status).toBe(429); 
+        });
+    });
+});

--- a/back-end/src/__tests__/utils/applicationValidator.test.js
+++ b/back-end/src/__tests__/utils/applicationValidator.test.js
@@ -1,4 +1,4 @@
-const { validateApplyForJob } = require("../../utils/applicationValidator");
+const { validateApplyForJob, validateUpdateStatus } = require("../../utils/applicationValidator");
 const GenericAppError = require("../../utils/genericAppError");
 
 describe("ApplyForJobValidator", () => {
@@ -13,12 +13,8 @@ describe("ApplyForJobValidator", () => {
         test("should pass validation for valid input", () => {
             req = {
                 body: {
-                    competences: [
-                        { competence_id: 1, years_of_experience: 5 }
-                    ],
-                    availabilities: [
-                        { from_date: "2023-01-01", to_date: "2023-12-31" }
-                    ]
+                    competences: [{ competence_id: 1, years_of_experience: 5 }],
+                    availabilities: [{ from_date: "2023-01-01", to_date: "2023-12-31" }]
                 }
             };
 
@@ -45,4 +41,43 @@ describe("ApplyForJobValidator", () => {
             });
         });
     });
+
+    describe("validateUpdateStatus", () => {
+        const invalidStatuses = [
+            { status: "pending" },
+            { status: 0 },
+            { status: null },
+            { status: [] },
+            { status: {} },
+            { status: undefined },
+        ];
+    
+        const validStatuses = [
+            { status: "accepted" },
+            { status: "rejected" },
+        ];
+    
+        test("should pass validation for valid input", () => {
+            validStatuses.forEach(input => {
+                req = { body: input };
+                validateUpdateStatus(req, res, next);
+                expect(next).toHaveBeenCalledWith();
+            });
+        });
+    
+        test("should fail validation for invalid input", () => {
+            invalidStatuses.forEach(input => {
+                req = { body: input };
+                validateUpdateStatus(req, res, next);
+                expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            });
+        });
+    
+        test("should fail validation when status is missing", () => {
+            req = { body: {} };
+            validateUpdateStatus(req, res, next);
+            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+        });
+    });
+
 });

--- a/back-end/src/api/applicationAPI.js
+++ b/back-end/src/api/applicationAPI.js
@@ -1,6 +1,6 @@
 const RequestHandler = require("./requestHandler");
 const Controller = require("../controller/controller");
-const { validateApplyForJob } = require("../utils/applicationValidator");
+const { validateApplyForJob, validateUpdateStatus } = require("../utils/applicationValidator");
 
 class ApplicationAPI extends RequestHandler {
   constructor() {
@@ -133,6 +133,7 @@ class ApplicationAPI extends RequestHandler {
      */
     this.router.patch(
       "/:id/status",
+      validateUpdateStatus,
       this.auth.authenticateUser.bind(this.auth),
       this.auth.authorizeRecruiter(this.controller), // Restrict to recruiters
       async (req, res, next) => {

--- a/back-end/src/controller/controller.js
+++ b/back-end/src/controller/controller.js
@@ -336,7 +336,7 @@ class Controller {
       }
 
       if (!["accepted", "rejected"].includes(status)) {
-        return next(GenericAppError.createBadRequestError("Invalid status"));
+        throw GenericAppError.createBadRequestError("Invalid status");
       }
 
       application.status = status;

--- a/back-end/src/utils/applicationValidator.js
+++ b/back-end/src/utils/applicationValidator.js
@@ -45,6 +45,17 @@ const applyForJobSchema = Joi.object({
     }),
 });
 
+const updateStatusSchema = Joi.object({
+  status: Joi.string()
+    .valid("accepted", "rejected")
+    .required()
+    .messages({
+      "any.required": "Status is required.",
+      "string.base": "Status must be a string.",
+      "any.only": "Invalid status. Allowed values: accepted, rejected.",
+    }),
+});
+
 const validateApplyForJob = (req, res, next) => {
   const { error } = applyForJobSchema.validate(req.body, { abortEarly: true });
   if (error) {
@@ -58,6 +69,20 @@ const validateApplyForJob = (req, res, next) => {
   next();
 };
 
+const validateUpdateStatus = (req, res, next) => {
+  const { error } = updateStatusSchema.validate(req.body, { abortEarly: true });
+  if (error) {
+    return next(
+      GenericAppError.createValidationError(
+        `Validation error: ${error.details.map((detail) => detail.message)}`,
+        error
+      )
+    );
+  }
+  next();
+}
+
 module.exports = {
   validateApplyForJob,
+  validateUpdateStatus,
 };


### PR DESCRIPTION
# Rate Limit added to express app
- added express rate-limit to the app
    -  rate set to 100 requests per 15 minutes
- full user case test for server.js created
- server.test.js also test the rate-limit
- dbmock changed to a singleton
- workflow updated to run the tests sequentially with npm run test:ci
- server.js: added a stop method and exports the server instance for the test file. 

# Bug Fix
Controller.updateApplicationStatus called next on input error, should throw error to the applicationAPI.
This is handled by the the Validation middleware as well so should never happen.

# Status Validation
- Added validateUpdateStatus middleware for the update status in applicationValidator. 
- ApplicationAPI("/:id/status")calls middleware validateUpdateStatus
- test created for the middleware


# Note
If changes creates conflicts let me know and i'll remove the conflicting parts for now.
