### PR TITLE
Logger added to applicationAPI, removal of person/all and authorization.authorizePersonRequest and update to GenericAppError

### DIFF
--- a/back-end/src/__tests__/api/applicationAPI.test.js
+++ b/back-end/src/__tests__/api/applicationAPI.test.js
@@ -453,7 +453,7 @@ describe("applicationApi", () => {
         }))
         newAuthMock.authorizeRecruiter.mockImplementation(() => {
             return (req, res, next) => {
-                const err = GenericAppError.createUnauthorizedError();
+                const err = GenericAppError.createAuthorizationError();
                 next(err);
             };
         });
@@ -468,13 +468,13 @@ describe("applicationApi", () => {
         
         newApp.use(newErrorHandler.handleError);
 
-        const errorMsg = GenericAppError.createUnauthorizedError().userMessage
+        const errorMsg = GenericAppError.createAuthorizationError().userMessage
        
        describe("getAllApplications", () => {
-           test("should return 401 if user is not a recruiter", async () => {
+           test("should return 403 if user is not a recruiter", async () => {
                 const response = await request(newApp)
                 .get("/api/application/all")
-                .expect(401);
+                .expect(403);
                     
                 expect(response.body).toEqual({ success: false, error:errorMsg });
                 expect(newControllerMock.getAllApplications).not.toHaveBeenCalled();
@@ -482,11 +482,11 @@ describe("applicationApi", () => {
         });
 
         describe("getApplicationById", () => {
-            test("should return 401 if user is not a recruiter", async () => {
+            test("should return 403 if user is not a recruiter", async () => {
 
                 const response = await request(newApp)
                     .get("/api/application/1")
-                    .expect(401);
+                    .expect(403);
 
                 expect(response.body).toEqual({ success: false, error:errorMsg });
                 expect(newControllerMock.getApplicationById).not.toHaveBeenCalled();
@@ -495,12 +495,12 @@ describe("applicationApi", () => {
         })
 
         describe("updateApplicationStatus", () => {
-            test("should return 401 if user is not a recruiter", async () => {
+            test("should return 403 if user is not a recruiter", async () => {
 
                 const response = await request(newApp)
                     .patch("/api/application/1/status")
                     .send({ status: "accepted" })
-                    .expect(401);
+                    .expect(403);
 
                 expect(response.body).toEqual({ success: false, error:errorMsg });
                 expect(newControllerMock.updateApplicationStatus).not.toHaveBeenCalled();

--- a/back-end/src/__tests__/api/auth/authorization.test.js
+++ b/back-end/src/__tests__/api/auth/authorization.test.js
@@ -48,41 +48,44 @@ describe("Auth", () => {
         beforeEach(() => {
             req = {};
         });
-
+    
         test("should authenticate user", async () => {
             req = { headers: { authorization: "Bearer token" } };
             jwt.verify.mockReturnValue(valid);
             await auth.authenticateUser(req, res, next);
             expect(req.decoded).toEqual(valid);
-            expect(next).toHaveBeenCalled();
+            expect(next).not.toHaveBeenCalledWith(expect.any(Error));
         });
-        test("should call next with an error since no header", async () => {
-            req = { headers: {}};
+    
+        test("should call next with an error 401 since no header", async () => {
+            req = { headers: {} };
             jwt.verify.mockReturnValue(valid);
             await auth.authenticateUser(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
         });
-        test("should call next with an error since invalid header", async () => {
-            req = { headers: {authorization: "Bearertoken"}};
+    
+        test("should call next with an error 401 since invalid header", async () => {
+            req = { headers: { authorization: "Bearertoken" } };
             jwt.verify.mockReturnValue(valid);
             await auth.authenticateUser(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
         });
-        test("should call next with an error since token is expired", async () => {
+    
+        test("should call next with an error 401 since token is expired", async () => {
             req = { headers: { authorization: "Bearer token" } };
-            jwt.sign.mockImplementation(() => { throw new jwt.TokenExpiredError("Token Expired"); });
+            jwt.verify.mockImplementation(() => { throw new jwt.TokenExpiredError("Token Expired"); });
             await auth.authenticateUser(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
         });
-        test("should call next with an error", async () => {
+    
+        test("should call next with a 500 error when verifyToken throws a generic error", async () => {
             req = { headers: { authorization: "Bearer token" } };
-            jwt.sign.mockImplementation(() => { throw new Error("Other issue with verify"); });
+            auth.verifyToken = jest.fn(() => { throw new Error("Generic verification error"); });
             await auth.authenticateUser(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
         });
-
     });
-
+    
     describe("authorizeRecruiter", () => {
         let req, res, next, controller;
         beforeEach(() => {
@@ -91,26 +94,27 @@ describe("Auth", () => {
             next = jest.fn();
             controller = new Controller();
         });
-
+    
         test("should authorize the person request and call next without an error", async () => {
             req = { params: { id: 1 }, decoded: { id: 2 } };
             controller.getUserRole.mockReturnValue("recruiter");
             await auth.authorizeRecruiter(controller)(req, res, next);
-            expect(next).not.toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).not.toHaveBeenCalledWith(expect.objectContaining({ status: 403 }));
         });
-        test("should not authorize the person request and call enxt with an error", async () => {
+    
+        test("should not authorize the person request and call next with a 403 error", async () => {
             req = { params: { id: 1 }, decoded: { id: 2 } };
             controller.getUserRole.mockReturnValue("applicant");
             await auth.authorizeRecruiter(controller)(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 403 }));
         });
-        test("should not authorize the person request and call enxt with an error", async () => {
+    
+        test("should not authorize the person request and call next with a 500 error when getUserRole returns an error", async () => {
             req = { params: { id: 1 }, decoded: { id: 2 } };
-            controller.getUserRole.mockReturnValue(new Error());
+            controller.getUserRole.mockRejectedValue(new Error("role error"));
             await auth.authorizeRecruiter(controller)(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }));
         });
-
     });
     
 });

--- a/back-end/src/__tests__/api/auth/authorization.test.js
+++ b/back-end/src/__tests__/api/auth/authorization.test.js
@@ -82,30 +82,7 @@ describe("Auth", () => {
         });
 
     });
-        
-    describe("authorizePersonRequest", () => {
-        let req, res, next, controller;
-        beforeEach(() => {
-            req = {};
-            res = {};
-            next = jest.fn();
-            controller = new Controller();
-        });
 
-        test("should authorize the person request and call next without an error", async () => {
-            req = { params: { id: 1 }, decoded: { id: 2 } };
-            controller.getUserRole.mockReturnValue("recruiter");
-            await auth.authorizePersonRequest(controller)(req, res, next);
-            expect(next).not.toHaveBeenCalledWith(expect.any(GenericAppError));
-        });
-        test("should not authorize the person request and call enxt with an error", async () => {
-            req = { params: { id: 1 }, decoded: { id: 2 } };
-            controller.getUserRole.mockReturnValue("applicant");
-            await auth.authorizePersonRequest(controller)(req, res, next);
-            expect(next).toHaveBeenCalledWith(expect.any(GenericAppError));
-        });
-
-    });
     describe("authorizeRecruiter", () => {
         let req, res, next, controller;
         beforeEach(() => {

--- a/back-end/src/__tests__/api/personAPI.test.js
+++ b/back-end/src/__tests__/api/personAPI.test.js
@@ -26,7 +26,7 @@ AuthHandler.mockImplementation(() => ({
         req.decoded = { id: 1, email: "john.doe@example.com" };
         next();
     }),
-    authorizePersonRequest: jest.fn(() => (req, res, next) => {
+    authorizeRecruiter: jest.fn(() => (req, res, next) => {
         next();
     }),
     extractUserData: jest.fn((person) => ({ id: person.id, email: person.email })),
@@ -270,7 +270,7 @@ describe("PersonApi", () => {
             const tempAuthMock = new AuthHandler();
             const tempPersonApi = new PersonApi(logger);
             tempAuthMock.authenticateUser.mockImplementation((req, res, next) => {next()});
-            tempAuthMock.authorizePersonRequest.mockImplementation((controller) => {
+            tempAuthMock.authorizeRecruiter.mockImplementation((controller) => {
                 return (req, res, next) => next(GenericAppError.createUnauthorizedError());
             });
             tempControllerMock.getPersonData.mockRejectedValue(GenericAppError.createInternalServerError());

--- a/back-end/src/__tests__/api/personAPI.test.js
+++ b/back-end/src/__tests__/api/personAPI.test.js
@@ -271,7 +271,7 @@ describe("PersonApi", () => {
             const tempPersonApi = new PersonApi(logger);
             tempAuthMock.authenticateUser.mockImplementation((req, res, next) => {next()});
             tempAuthMock.authorizeRecruiter.mockImplementation((controller) => {
-                return (req, res, next) => next(GenericAppError.createUnauthorizedError());
+                return (req, res, next) => next(GenericAppError.createAuthorizationError());
             });
             tempControllerMock.getPersonData.mockRejectedValue(GenericAppError.createInternalServerError());
             tempPersonApi.controller = tempControllerMock;
@@ -282,7 +282,7 @@ describe("PersonApi", () => {
 
             const response = await request(tempApp)
                 .get(`/api/person/id/${person.id}`)
-                .expect(401);
+                .expect(403);
             expect(response.status).not.toBe(500);
             expect(tempControllerMock.getPersonData).not.toHaveBeenCalled();
         });

--- a/back-end/src/__tests__/server.test.js
+++ b/back-end/src/__tests__/server.test.js
@@ -93,7 +93,7 @@ describe("Testing Backend full flow use cases with dummy database",()=>{
         test("Should return 404 with an invalid route", async () => {
             await request(app).get("/test").expect(404);
         });
-        test("Should return 401  if not authenticated", async () => {
+        test("Should return 401  if not token is missing", async () => {
             await request(app).get("/api/person/me").expect(401);
         });
         test("Should return 401  if not authenticated", async () => {
@@ -151,7 +151,7 @@ describe("Testing Backend full flow use cases with dummy database",()=>{
             const res= await request(app)
             .get("/api/application/all")
             .set("Authorization", `Bearer ${token}`)
-            .expect(401);
+            .expect(403);
         });
 
         test("should have 0 applications", async () => {

--- a/back-end/src/__tests__/utils/genericAppError.test.js
+++ b/back-end/src/__tests__/utils/genericAppError.test.js
@@ -34,10 +34,10 @@ describe("GenericAppError", () => {
     });
 
     test("should create an unauthorized error", () => {
-        const error = GenericAppError.createUnauthorizedError();
+        const error = GenericAppError.createAuthorizationError();
         expect(error).toBeInstanceOf(GenericAppError);
         expect(error.message).toBe("Unauthorized access");
-        expect(error.status).toBe(401);
+        expect(error.status).toBe(403);
         expect(error.userMessage).toBe("You are not authorized to perform this action.");
     });
 

--- a/back-end/src/api/apiLoader.js
+++ b/back-end/src/api/apiLoader.js
@@ -10,7 +10,7 @@ class ApiLoader {
    * Creates a new array of APIs
    */
   constructor(logger) {
-    this.apis = [new PersonApi(logger), new ApplicationAPI()];
+    this.apis = [new PersonApi(logger), new ApplicationAPI(logger)];
   }
 
   /**

--- a/back-end/src/api/applicationAPI.js
+++ b/back-end/src/api/applicationAPI.js
@@ -3,8 +3,8 @@ const Controller = require("../controller/controller");
 const { validateApplyForJob, validateUpdateStatus } = require("../utils/applicationValidator");
 
 class ApplicationAPI extends RequestHandler {
-  constructor() {
-    super("/application");
+  constructor(logger) {
+    super("/application", logger);
     this.controller = new Controller();
   }
 
@@ -30,8 +30,10 @@ class ApplicationAPI extends RequestHandler {
             competences,
             availabilities
           );
+          this.logSuccess(`User ${req.decoded.id} successfully created an application`);
           this.sendSuccess(res, 201, application);
         } catch (error) {
+          
           next(error);
         }
       }
@@ -50,6 +52,7 @@ class ApplicationAPI extends RequestHandler {
       async (req, res, next) => {
         try {
           const competences = await this.controller.listAllCompetences();
+          this.logSuccess(`User ${req.decoded.id} successfully retrieved the competences`);
           this.sendSuccess(res, 200, competences);
         } catch (error) {
           next(error);
@@ -72,6 +75,7 @@ class ApplicationAPI extends RequestHandler {
           const application = await this.controller.getUserApplication(
             req.decoded.id
           );
+          this.logSuccess(`User ${req.decoded.id} successfully retrieved their application`);
           this.sendSuccess(res, 200, application);
         } catch (error) {
           next(error);
@@ -93,6 +97,7 @@ class ApplicationAPI extends RequestHandler {
       async (req, res, next) => {
         try {
           const applications = await this.controller.getAllApplications();
+          this.logSuccess(`User ${req.decoded.id} successfully retrieved all applications`);
           this.sendSuccess(res, 200, applications);
         } catch (error) {
           next(error);
@@ -115,6 +120,7 @@ class ApplicationAPI extends RequestHandler {
       async (req, res, next) => {
         try {
           const application = await this.controller.getApplicationById(req.params.id);
+          this.logSuccess(`User ${req.decoded.id} successfully retrieved application: ${req.params.id}`);
           this.sendSuccess(res, 200, application);
         } catch (error) {
           next(error);
@@ -140,6 +146,7 @@ class ApplicationAPI extends RequestHandler {
         try {
           const { status } = req.body;
           const updatedApplication = await this.controller.updateApplicationStatus(req.params.id, status);
+          this.logSuccess(`User ${req.decoded.id} successfully update the status of application:${req.params.id} to ${status}`);
           this.sendSuccess(res, 200, updatedApplication);
         } catch (error) {
           next(error);

--- a/back-end/src/api/auth/authorization.js
+++ b/back-end/src/api/auth/authorization.js
@@ -64,36 +64,6 @@ class AuthHandler{
         }
     }
 
-
-    /**
-     * Middleware function that authorizes the user for person requests
-     * If the requested person's id does not match the id in the decoded token,
-     * it checks if the user has the 'recruiter' role.
-     * @param {Object} controller - The controller object
-     * @param {Object} req.params.id - The id of the requested person data
-     * @param {Object} req.decoded.id - The id in the decoded token
-     * @returns {Function} - The middleware function to check if a user is authorized
-     * @throws {GenericAppError} - If the user is not authorized
-     * @throws {GenericAppError} - If there is an error in the authorization process
-     */
-    // TODO: we can remove this
-    authorizePersonRequest(controller) {
-        return async (req, res, next) => {
-            if (String(req.params.id) !== String(req.decoded.id)) {
-                try {
-                    const role = await controller.getUserRole(req.decoded.id);
-                    if (role !== 'recruiter') {
-                        return next(GenericAppError.createUnauthorizedError(`User[${req.decoded.id}, ${role}] tried accessing user [${req.params.id}]`));
-                    }
-                } 
-                catch (error) {
-                    return next(GenericAppError.createInternalServerError("Authorization error", error));
-                }
-            }
-            return next();
-        };
-    }
-
     /**
      * Middleware function that authorizes the user for recruiter requests
      * Checks if the user has the 'recruiter' role.

--- a/back-end/src/api/auth/authorization.js
+++ b/back-end/src/api/auth/authorization.js
@@ -78,7 +78,7 @@ class AuthHandler{
             try {
                 const role = await controller.getUserRole(req.decoded.id);
                 if (role !== 'recruiter') {
-                    return next(GenericAppError.createUnauthorizedError(`User[${req.decoded.id}, ${role}] tried accessing user [${req.params.id}]`));
+                    return next(GenericAppError.createAuthorizationError(`User[${req.decoded.id}, ${role}] tried accessing user [${req.params.id}]`));
                 }
             } 
             catch (error) {

--- a/back-end/src/api/personAPI.js
+++ b/back-end/src/api/personAPI.js
@@ -50,25 +50,6 @@ class PersonApi extends RequestHandler {
     );
 
     /**
-     * async function that finds all persons
-     * @param {Object} req - The request object
-     * @param {Object} res - The response object
-     * @param {Function} next - The next function
-     */
-
-    this.router.get("/all", 
-      async (req, res, next) => {
-      try { 
-        const persons = await this.controller.findAllPersons();
-        this.logSuccess(`All users from the database returned`);
-        this.sendSuccess(res, 200, persons);
-      } 
-      catch (error) {
-        next(error);
-      }
-    });
-
-    /**
      * async function to login a person
      * @param {Object} req - The request object
      * @param {Object} res - The response object

--- a/back-end/src/api/personAPI.js
+++ b/back-end/src/api/personAPI.js
@@ -102,7 +102,7 @@ class PersonApi extends RequestHandler {
       "/id/:id",
       validateGetUser,
       this.auth.authenticateUser.bind(this.auth),
-      this.auth.authorizePersonRequest(this.controller),
+      this.auth.authorizeRecruiter(this.controller),
       async (req, res, next) => {
         try {
           const person = await this.controller.getPersonData(req.params.id);

--- a/back-end/src/api/requestHandler.js
+++ b/back-end/src/api/requestHandler.js
@@ -43,7 +43,11 @@ class RequestHandler {
    * @param {string} msg - The message to log 
    */
   logSuccess(msg){
-    this.logger.log("info", msg);
+    try {
+      this.logger.log("info", msg);
+    } catch (error) {
+      throw GenericAppError.createInternalServerError("Logger failed", error)
+    }
   }
 
   /**

--- a/back-end/src/utils/genericAppError.js
+++ b/back-end/src/utils/genericAppError.js
@@ -45,10 +45,10 @@ class GenericAppError extends Error {
 
     /**
      * Used for authprization failures (unauthorized access)
-     * @returns {GenericAppError} - 401 Unauthorized
+     * @returns {GenericAppError} - 403 Forbidden
      */
-    static createUnauthorizedError(message = "Unauthorized access", error = null, userMessage = "You are not authorized to perform this action.") {
-        return new GenericAppError(message, 401, error, userMessage);
+    static createAuthorizationError(message = "Unauthorized access", error = null, userMessage = "You are not authorized to perform this action.") {
+        return new GenericAppError(message, 403, error, userMessage);
     }
     /**
      * Used for authentication failures


### PR DESCRIPTION
# Logger added to applicaitonAPI
The logger is now implemented in the applicationAPI.
changed files: 
- applicationAPI.js
- apiLoader.js
- applicationAPI.test.js
- requestHandler.js: added a try catch block for the logging, to ease tests

# Removal of person/all and authorization.authorizePersonRequest
- method removed from authorization.js
- personAPI updated to use authorizeRecruiter instead
- personAPI.test.js and authroization.test.js updated

# GenericAppError
- renamed createUnauthorizedError -> createAuthorizationError to better fit other class method names
- updated the statuscode of authroization error to 403
- authorization.js and tests updated to use the new name and status code
- more extensive tests for authorization.js added to check the different status codes